### PR TITLE
Move score to top and tidy playfield (221)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<pre id=m><script>onkeyup=e=>d=e;l=s=setInterval("m[m[l-s]]=i=0;I*=!m[m[-++s]=p=p+[32,-1,-32,1][d.which&3]&I];m[p]=2;for(h='.o#';i<I;m.innerHTML=h+s)h+=['\\n'[i++&31]]+h[i^(o=p^o?o:s*l++&I)?m[i]|0:1]",o=p=83,I=511)</script>
+<pre id=m><script>onkeyup=e=>d=e;l=s=setInterval("m[m[l-s]]=i=0;I*=!m[m[-++s]=p=p+[32,-1,-32,1][d.which&3]&I];m[p]=2;for(h=s;i<I;m.innerHTML=h)h+=['\\n'[i++&31]]+'.o#'[i^(o=p^o?o:s*l++&I)?m[i]|0:1]",o=p=83,I=511)</script>


### PR DESCRIPTION
- Assigns the score as the initial value for the playfield.
- Moves the line-break test before assigning the grid element (keeps score on line 1)
- Charmap (`.o#'`) uses literally rather than assigning it to `h`.

![screen shot 2016-06-29 at 12 04 38](https://cloud.githubusercontent.com/assets/588665/16449976/5cc887e0-3df2-11e6-9b95-f1e7793a16f0.png)
